### PR TITLE
Add Docker image on hub.docker.com

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on: push
 
 jobs:
   publish:
-    name: Publish to PyPI
+    name: Publish to PyPI and hub.docker
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -33,5 +33,26 @@ jobs:
       - name: Build package
         run: uv run hatch build
 
+      - name: Get version
+        id: get_version
+        run: |
+          echo "version=$(uv run hatch version)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/mcp-ollama:${{ steps.get_version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/mcp-ollama:latest
+
       - name: Publish package distributions to PyPI
+        if: ${{ github.repository_owner == 'emgeee' }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-alpine
+
+WORKDIR /app
+
+RUN --mount=type=bind,source=dist/,target=/tmp/dist \
+    pip install --no-cache-dir /tmp/dist/*.whl \
+    && adduser -D -u 10001 appuser
+
+USER appuser
+
+CMD ["python", "-m", "mcp_ollama"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/
 }
 ```
 
+##R Running in Docker
+
+Usage examples for running mcp-ollama with Docker are documented on the [Docker Hub page](https://hub.docker.com/r/wuodan/mcp-ollama).
+
 ### Development
 
 Install in development mode:


### PR DESCRIPTION
With this change a Docker image is being built by the pipeline and then pushed to hub.docker.com.

All you (as project owner) have to do is:
- register at hub.docker.com
- create a `emgeee/mcp-ollama` repository at hub.docker.com
  - feel free to use my repo-overview text: [hub.docker-repository_overview.md](https://github.com/user-attachments/files/22730115/hub.docker-repository_overview.md)
- create a personal access token on hub.docker: Account Settings > Personal access tokens > Generate new token
- add that token and your hub.docker account name as github-repo-action-repository-secrets
  - https://github.com/Wuodan/mcp-ollama/settings/secrets/actions
  - key for account-name: DOCKERHUB_USERNAME
  - key for token: DOCKERHUB_TOKEN
  
If you accept this PR, then I will happily delete my docker repository for `mcp-ollama` on [https://hub.docker.com/repository/docker/wuodan/mcp-ollama/general](https://hub.docker.com/repository/docker/wuodan/mcp-ollama/general)!